### PR TITLE
Fix x11 window creation.

### DIFF
--- a/src/OpenTK/Platform/X11/API.cs
+++ b/src/OpenTK/Platform/X11/API.cs
@@ -1323,12 +1323,12 @@ XF86VidModeGetGammaRampSize(
                 {
                     XSetWindowAttributes attr = attributes.Value;
                     return XCreateWindow(display, parent, x, y, width, height, border_width, depth,
-                        (int)@class, visual, (IntPtr)valuemask, &attr);
+                        (int)@class, visual, (IntPtr)valuemask, (IntPtr)(&attr));
                 }
                 else
                 {
                     return XCreateWindow(display, parent, x, y, width, height, border_width, depth,
-                        (int)@class, visual, (IntPtr)valuemask, null);
+                        (int)@class, visual, (IntPtr)valuemask, (IntPtr)null);
                 }
             }
         }

--- a/src/OpenTK/Platform/X11/Functions.cs
+++ b/src/OpenTK/Platform/X11/Functions.cs
@@ -65,7 +65,7 @@ namespace OpenTK.Platform.X11
         public extern static IntPtr XSynchronize(IntPtr display, bool onoff);
 
         [DllImport("libX11", EntryPoint = "XCreateWindow")]
-        public unsafe extern static IntPtr XCreateWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, int depth, int xclass, IntPtr visual, IntPtr valuemask, XSetWindowAttributes* attributes);
+        public extern static IntPtr XCreateWindow(Display display, Window parent, int x, int y, int width, int height, int borderWidth, int depth, int xclass, IntPtr visual, IntPtr valueMask, IntPtr attributes);
 
         [DllImport("libX11", EntryPoint = "XCreateSimpleWindow")]//, CLSCompliant(false)]
         public extern static IntPtr XCreateSimpleWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, UIntPtr border, UIntPtr background);


### PR DESCRIPTION
### Purpose of this PR

* Fix creation of X11 window.
* Affects the X11 backend.

### Testing status

* Before it didn't work, now it does.

Fixes this exception:
```
System.Runtime.InteropServices.MarshalDirectiveException: Cannot marshal 'parameter #12': Pointers cannot reference marshaled structures.  Use ByRef instead.
   at OpenTK.Platform.X11.Functions.XCreateWindow(IntPtr display, IntPtr parent, Int32 x, Int32 y, Int32 width, Int32 height, Int32 border_width, Int32 depth, Int32 xclass, IntPtr visual, IntPtr valuemask, XSetWindowAttributes* attributes)
```