### PR TITLE
Encoding on linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,36 +1,37 @@
- # ! / u s r / b i n / e n v   b a s h  
-  
- s e t   - e u  
- s e t   - o   p i p e f a i l  
-  
- c d   ` d i r n a m e   $ 0 `  
-  
- F S I A R G S = " "  
- O S = $ { O S : - " u n k n o w n " }  
- i f   [ [   " $ O S "   ! =   " W i n d o w s _ N T "   ] ]  
- t h e n  
-     F S I A R G S = " - - f s i a r g s   - d : M O N O "  
- f i  
-  
- f u n c t i o n   r u n ( )   {  
-     i f   [ [   " $ O S "   ! =   " W i n d o w s _ N T "   ] ]  
-     t h e n  
-         m o n o   " $ @ "  
-     e l s e  
-         " $ @ "  
-     f i  
- }  
-  
- r u n   . p a k e t / p a k e t . b o o t s t r a p p e r . e x e  
-  
- i f   [ [   " $ O S "   ! =   " W i n d o w s _ N T "   ] ]   & &  
-               [   !   - e   ~ / . c o n f i g / . m o n o / c e r t s   ]  
- t h e n  
-     m o z r o o t s   - - i m p o r t   - - s y n c   - - q u i e t  
- f i  
-  
- r u n   . p a k e t / p a k e t . e x e   r e s t o r e  
-  
- [   !   - e   b u i l d . f s x   ]   & &   r u n   . p a k e t / p a k e t . e x e   u p d a t e  
- [   !   - e   b u i l d . f s x   ]   & &   r u n   p a c k a g e s / F A K E / t o o l s / F A K E . e x e   i n i t . f s x  
- r u n   p a c k a g e s / F A K E / t o o l s / F A K E . e x e   " $ @ "   $ F S I A R G S   b u i l d . f s x
+#!/usr/bin/env  bash  
+ 
+set -eu  
+set -o pipefail  
+ 
+cd `dirname $0`  
+ 
+FSIARGS=""
+OS=${OS:-"unknown"}
+if [[ "$OS" != "Windows_NT" ]]
+then
+  FSIARGS="--fsiargs -d:MONO"
+fi
+ 
+function run() {
+  if [[ "$OS" != "Windows_NT" ]]
+  then
+    mono "$@"
+  else
+    "$@"
+  fi
+}
+ 
+run .paket/paket.bootstrapper.exe
+ 
+if [[ "$OS" != "Windows_NT" ]] &&
+   [ ! -e ~/.config/.mono/certs ]
+then
+  mozroots --import --sync --quiet
+fi
+ 
+run .paket/paket.exe restore
+ 
+[ ! -e build.fsx ] && run .paket/paket.exe update
+[ ! -e build.fsx ] && run packages/FAKE/tools/FAKE.exe init.fsx
+run packages/FAKE/tools/FAKE.exe "$@" $FSIARGS build.fsx
+


### PR DESCRIPTION
### Purpose of this PR

* Build on linux (changing encoding for build.sh

### Testing status

* Build can be runned but fail


```
$ ./build.sh 
Checking Paket version (downloading latest stable)...
Paket.exe 5.249.2 is up to date.
Paket version 5.249.2
The last restore is still up to date. Nothing left to do.
Performance:
 - Runtime: 313 milliseconds
FsiEvaluationException:

Error: 
	
	/home/alberto/projects/csharp/opentk/build.fsx(121,27): error FS0041: A unique overload for method 'GetFileNameWithoutExtension' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: Path.GetFileNameWithoutExtension(path: ReadOnlySpan<char>) : ReadOnlySpan<char>, Path.GetFileNameWithoutExtension(path: string) : string
	

Output: [Loading /home/alberto/projects/csharp/opentk/build.fsx]
	

Input: /home/alberto/projects/csharp/opentk/build.fsx
\Arguments: 
  C:\fsi.exe
  --define:MONO

Exception: Yaaf.FSharp.Scripting.FsiEvaluationException: Error while compiling or executing fsharp snippet. ---> System.Exception: Operation failed. The error text has been printed in the error stream. To return the corresponding FSharpErrorInfo use the EvalInteractionNonThrowing, EvalScriptNonThrowing or EvalExpressionNonThrowing
  at Microsoft.FSharp.Compiler.Interactive.Shell+FsiEvaluationSession.commitResult[a,b] (Microsoft.FSharp.Core.FSharpChoice`2[T1,T2] res) [0x00030] in <58ebd1c7ddab8ea7a7450383c7d1eb58>:0 
  at Microsoft.FSharp.Compiler.Interactive.Shell+FsiEvaluationSession.EvalScript (System.String filePath) [0x00017] in <58ebd1c7ddab8ea7a7450383c7d1eb58>:0 
  at Yaaf.FSharp.Scripting.Helper+evalScript@1303.Invoke (System.String arg00) [0x00001] in <5969d85fccf1c534a74503835fd86959>:0 
  at Yaaf.FSharp.Scripting.Helper+save_@1276-2[a].Invoke (Microsoft.FSharp.Core.Unit unitVar0) [0x00001] in <5969d85fccf1c534a74503835fd86959>:0 
  at Yaaf.FSharp.Scripting.Helper.consoleCapture[a] (System.IO.TextWriter out, System.IO.TextWriter err, Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] f) [0x0001a] in <5969d85fccf1c534a74503835fd86959>:0 
  at Yaaf.FSharp.Scripting.Helper.redirectOut@1247[a] (System.Boolean preventStdOut, Yaaf.FSharp.Scripting.Helper+OutStreamHelper out, Yaaf.FSharp.Scripting.Helper+OutStreamHelper err, Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] f) [0x0006e] in <5969d85fccf1c534a74503835fd86959>:0 
  at Yaaf.FSharp.Scripting.Helper+save_@1275-1[a].Invoke (System.String text) [0x0002c] in <5969d85fccf1c534a74503835fd86959>:0 
   --- End of inner exception stack trace ---
  at Yaaf.FSharp.Scripting.Helper+save_@1275-1[a].Invoke (System.String text) [0x0009e] in <5969d85fccf1c534a74503835fd86959>:0 
  at Yaaf.FSharp.Scripting.Helper+session@1306.Yaaf-FSharp-Scripting-IFsiSession-EvalScriptWithOutput (System.String ) [0x00001] in <5969d85fccf1c534a74503835fd86959>:0 
  at Fake.FSIHelper.runScriptUncached (System.Boolean useCache, System.String scriptPath, System.Collections.Generic.IEnumerable`1[T] fsiOptions, System.Boolean printDetails, Fake.FSIHelper+CacheInfo cacheInfo, System.IO.TextWriter out, System.IO.TextWriter err) [0x00187] in <5969d85fccf1c534a74503835fd86959>:0 
/home/alberto/projects/csharp/opentk/build.fsx(121,27): error FS0041: A unique overload for method 'GetFileNameWithoutExtension' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: Path.GetFileNameWithoutExtension(path: ReadOnlySpan<char>) : ReadOnlySpan<char>, Path.GetFileNameWithoutExtension(path: string) : string
```

### Comments

relates with #4 
